### PR TITLE
Apply recent changes to py-fsrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.2",
+    "version": "1.2.0",
     "license": "MIT",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,6 @@ class SchedulingCards {
       this.hard.state = State.Learning;
       this.good.state = State.Learning;
       this.easy.state = State.Review;
-      this.again.lapses += 1;
     } else if (state === State.Learning || state === State.Relearning) {
       this.again.state = state;
       this.hard.state = state;

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,27 +276,27 @@ export class FSRS {
   ): void {
     s.again.difficulty = this.next_difficulty(last_d, Rating.Again);
     s.again.stability = this.next_forget_stability(
-      s.again.difficulty,
+      last_d,
       last_s,
       retrievability
     );
     s.hard.difficulty = this.next_difficulty(last_d, Rating.Hard);
     s.hard.stability = this.next_recall_stability(
-      s.hard.difficulty,
+      last_d,
       last_s,
       retrievability,
       Rating.Hard
     );
     s.good.difficulty = this.next_difficulty(last_d, Rating.Good);
     s.good.stability = this.next_recall_stability(
-      s.good.difficulty,
+      last_d,
       last_s,
       retrievability,
       Rating.Good
     );
     s.easy.difficulty = this.next_difficulty(last_d, Rating.Easy);
     s.easy.stability = this.next_recall_stability(
-      s.easy.difficulty,
+      last_d,
       last_s,
       retrievability,
       Rating.Easy


### PR DESCRIPTION
In the past weeks, two changes affecting how the state of a card evolves when reviewed have been made to the python implementation of FSRS:

- https://github.com/open-spaced-repetition/py-fsrs/commit/eca79c38d88b60c00807fd32baeaa691bcb8ae38
- https://github.com/open-spaced-repetition/py-fsrs/commit/9980d8522c9bf097c744e5b92ba300dfc7863ad0

The changes in this pull request should bring the JS version back in sync with the python implementation. To validate this, I have used both to simulate all possible rating sequences of lengths up to 5 and then compared the results between both implementations.

Besides some minor floating point inaccuracies, this update to fsrs.js behaves exactly the same as the python reference.

I'm having some trouble installing the necessary dependencies to run the included JS tests
but those seem to be either identical to the python tests (which are still passing) or unaffected by these changes.